### PR TITLE
Added [enabled] option to make timer only 'count' when slide is visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ If you want to add a timer in raw HTML, you can use the following code snippet i
 <script src="_extensions/produnis/timer/timer.js"></script>
 <script>
     document.addEventListener("DOMContentLoaded", function () {
-        initializeTimer("UNIQUE-ID", SECONDS); 
+        initializeTimer("UNIQUE-ID", SECONDS, FOCUS_BOOL); 
     });
 </script>
 ```
 
-...and replace `UNIQUE-ID` with a (tadaaa) unique ID and `SECONDS` with the seconds to count down.
+...and replace `UNIQUE-ID` with a (tadaaa) unique ID, `SECONDS` with the seconds to count down, and 'FOCUS_BOOL' with `true` or `false` to indicate if the timer should only be active when the slide is in **focus** or start when the presentation does.
 
 Here is an example of 4 minutes of waiting:
 
@@ -40,7 +40,7 @@ Please think about this for 4 minutes.
 <script src="_extensions/produnis/timer/timer.js"></script>
 <script>
     document.addEventListener("DOMContentLoaded", function () {
-        initializeTimer("4minWaiting", 240); 
+        initializeTimer("4minWaiting", 240, true); 
     });
 </script>
 ```
@@ -59,12 +59,9 @@ filters:
 Having the filter ready, you can add a timer with 
 
 ```
-:::{.timer #UNIQUE-ID seconds=100}
+:::{.timer #UNIQUE-ID seconds=100 onfocus=true}
 :::
 ```
-
-
-
 
 You can use as many timers on your slides as you want, as long as you use a unique `UNIQUE-ID` every time.
 

--- a/_extensions/timer/timer.css
+++ b/_extensions/timer/timer.css
@@ -26,7 +26,9 @@
   stroke-linecap: round;
   transform: rotate(90deg);
   transform-origin: center;
-  transition: 1s linear all;
+  /* data update happens every 1s so keep transition duration as less,
+     otherwise you get strange behaviour, mainly jumps */
+  transition: 0.9s ease-in-out all;
   fill-rule: nonzero;
   stroke: currentColor;
 }

--- a/_extensions/timer/timer.js
+++ b/_extensions/timer/timer.js
@@ -19,7 +19,7 @@ const COLOR_CODES = {
 };
 
 // Funktion zur Initialisierung des Timers in einem Container
-function initializeTimer(containerId, timeLimit) {
+function initializeTimer(containerId, timeLimit, focusRequired) {
   let timePassed = 0;
   let timeLeft = timeLimit;
   let timerInterval = null;
@@ -50,11 +50,14 @@ function initializeTimer(containerId, timeLimit) {
     </div>
   `;
 
-  startTimer();
-
   // Startet den Timer für einen bestimmten Container
-  function startTimer() {
+  (function startTimer() {
     timerInterval = setInterval(() => {
+      
+      if(focusRequired && isHidden()) {
+        return;
+      }
+
       timePassed = timePassed += 1;
       timeLeft = timeLimit - timePassed;
       document.getElementById(`${containerId}-label`).innerHTML = formatTime(
@@ -67,6 +70,17 @@ function initializeTimer(containerId, timeLimit) {
         onTimesUp();
       }
     }, 1000);
+  })()
+
+  function isHidden() {
+    let timecont = document.getElementById(containerId);
+    let ancestor = timecont.parentNode;
+
+    // look if the section element, the 'slide', is visible
+    while (ancestor.tagName !== 'SECTION') {
+      ancestor = ancestor.parentNode;
+    }
+    return ancestor.hidden;
   }
 
   // Funktion, die aufgerufen wird, wenn der Timer abgelaufen ist
@@ -100,19 +114,14 @@ function initializeTimer(containerId, timeLimit) {
     }
   }
 
-  // Funktion zur Berechnung des Anteils der verstrichenen Zeit
-  function calculateTimeFraction() {
-    const rawTimeFraction = timeLeft / timeLimit;
-    return rawTimeFraction - (1 / timeLimit) * (1 - rawTimeFraction);
-  }
-
   // Funktion zur Festlegung der Strichlänge des verbleibenden Pfades basierend auf dem Anteil der verstrichenen Zeit
   function setCircleDasharray() {
-    const circleDasharray = `${(
-      calculateTimeFraction() * FULL_DASH_ARRAY
-    ).toFixed(0)} 283`;
+    // 
+    let circle_proportions = timeLeft / timeLimit * FULL_DASH_ARRAY + '% ';
+    circle_proportions += (1 - timeLeft / timeLimit) * FULL_DASH_ARRAY + '%';
+    
     document
       .getElementById(`${containerId}-path-remaining`)
-      .setAttribute("stroke-dasharray", circleDasharray);
+      .setAttribute("stroke-dasharray", circle_proportions);
   }
 }

--- a/_extensions/timer/timer.js
+++ b/_extensions/timer/timer.js
@@ -116,9 +116,8 @@ function initializeTimer(containerId, timeLimit, focusRequired) {
 
   // Funktion zur Festlegung der Strichlänge des verbleibenden Pfades basierend auf dem Anteil der verstrichenen Zeit
   function setCircleDasharray() {
-    // 
-    let circle_proportions = timeLeft / timeLimit * FULL_DASH_ARRAY + '% ';
-    circle_proportions += (1 - timeLeft / timeLimit) * FULL_DASH_ARRAY + '%';
+    let circle_proportions = timeLeft / timeLimit * FULL_DASH_ARRAY + ' ';
+    circle_proportions += (1 - timeLeft / timeLimit) * FULL_DASH_ARRAY + '';
     
     document
       .getElementById(`${containerId}-path-remaining`)

--- a/_extensions/timer/timer.lua
+++ b/_extensions/timer/timer.lua
@@ -5,26 +5,27 @@ quarto.doc.add_html_dependency({
   stylesheets = {"timer.css"}
 })
 
-function Div(div)
-    if div.classes[1] == "timer" then
-        local containerId = div.identifier
-        local timeLimit = tonumber(div.attributes["seconds"]) or 300  -- Default: 300 Sekunden
-
-        local htmlSnippet = string.format([[
-            <div id="%s"></div>
-            <script>
-                document.addEventListener("DOMContentLoaded", function () {
-                    initializeTimer("%s", %d);
-                });
-            </script>
-        ]], containerId, containerId, timeLimit)
-
-        return pandoc.RawBlock("html", htmlSnippet)
-    end
-    return div
-end
-
--- Füge den Filter zu Pandoc hinzu
 return {
-    { Div = Div }
+    -- Füge den Filter zu Pandoc hinzu
+    {
+        Div = function (div)
+            if div.classes[1] == "timer" then
+                local containerId = div.identifier
+                local timeLimit = tonumber(div.attributes["seconds"]) or 300  -- Default: 300 Sekunden
+                local focusRequired = div.attributes["onfocus"] or true -- timers only run when visible by default
+            
+                local htmlSnippet = string.format([[
+                    <div id="%s"></div>
+                    <script>
+                        document.addEventListener("DOMContentLoaded", function () {
+                            initializeTimer("%s", %d, %s);
+                        });
+                    </script>
+                ]], containerId, containerId, timeLimit, focusRequired)
+
+                return pandoc.RawBlock("html", htmlSnippet)
+            end
+            return div
+        end
+    }
 }


### PR DESCRIPTION
Hi,

A nice visual timer - thanks.
I wanted the timer to only 'work' when it's visible rather than when the presentation starts.
I've added the option - enabled by default - that the timer starts when the slide is visible.
It pauses when hidden.

I also smoothed out the progress transition. There was a race conditions before where either the JS or CSS would 'tick' irregularly before the other. This would sometimes cause the visual progress to jump (in Firefox anyway). In the CSS I reduced the duration to < 1s.

I did some minor other code reductions in the JS and Lua files.

Cheers,
Cyrille